### PR TITLE
Support/require PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"static analysis"
 	],
 	"require": {
-		"php": "^7.1 || ^8.0",
-		"spaze/phpstan-disallowed-calls": "^1.4.0 || ^2.0.0 || ^3.0.0"
+		"php": "^7.4 || ^8.0",
+		"spaze/phpstan-disallowed-calls": "^4.0.0"
 	}
 }


### PR DESCRIPTION
Support/require the newest phpstan-disallowed-calls that supports/requires PHPStan 2.0.

Bring this in line with the main extension, and although it would work with older releases as well, I'd like these two (the phpstan-disallowed-calls and this config) to be in sync.